### PR TITLE
upgrade sentinel go version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ Temporary Items
 
 # Local History for Visual Studio Code
 .history/
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,12 @@ go 1.14
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
-	github.com/alibaba/sentinel-golang v1.0.0
+	github.com/alibaba/sentinel-golang v1.0.1
 	github.com/coreos/etcd v3.3.25+incompatible
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-00010101000000-000000000000 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/hashicorp/consul/api v1.4.0
@@ -19,6 +20,6 @@ require (
 	google.golang.org/grpc v1.33.2 // indirect
 )
 
-replace github.com/coreos/bbolt v1.3.5 => go.etcd.io/bbolt v1.3.5
-
 replace github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.0.0
+
+replace google.golang.org/grpc => google.golang.org/grpc v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/alibaba/sentinel-golang v1.0.0-M2 h1:FzZvrIBmVWTZx5Q4c/x0Vi/Y85YclSyW
 github.com/alibaba/sentinel-golang v1.0.0-M2/go.mod h1:CdsQi8Ng969/2GGsnd1fcky+uGXfttxCNE1FA3vp7LM=
 github.com/alibaba/sentinel-golang v1.0.0 h1:J8sl1UyLpSVsFuuamg7/NkBu4evnEaI5MkFoRms5tKE=
 github.com/alibaba/sentinel-golang v1.0.0/go.mod h1:C1Hq44JD9bBIvqTWRmpZB4/M9optaqgPXzJdesG6a20=
+github.com/alibaba/sentinel-golang v1.0.1 h1:WlhN0XUxRyfkiDc8TO6CcRrnakwFP9zFtvJTYxZRCgI=
+github.com/alibaba/sentinel-golang v1.0.1/go.mod h1:QsB99f/z35D2AiMrAWwgWE85kDTkBUIkcmPrRt+61NI=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.18 h1:zOVTBdCKFd9JbCKz9/nt+FovbjPFmb7mUnp8nH9fQBA=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.18/go.mod h1:v8ESoHo4SyHmuB4b1tJqDHxfTGEciD+yhvOU/5s1Rfk=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -427,6 +429,8 @@ github.com/shirou/gopsutil v2.19.12+incompatible h1:WRstheAymn1WOPesh+24+bZKFkqr
 github.com/shirou/gopsutil v2.19.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v3.20.11-0.20201116082039-2fb5da2f2449+incompatible h1:Wll9sV8SqrD0cSI17l1L1Q2ZcqhhoDb1CUN+6TarZ3I=
 github.com/shirou/gopsutil v3.20.11-0.20201116082039-2fb5da2f2449+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v3.20.11+incompatible h1:LJr4ZQK4mPpIV5gOa4jCOKOGb4ty4DZO54I4FGqIpto=
+github.com/shirou/gopsutil v3.20.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
upgrade sentinel go version: v1.0.0=>v1.0.1

replace google.golang.org/grpc:  v1.33.2 => v1.26.0